### PR TITLE
Make log level fieldname configurable

### DIFF
--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -171,6 +171,8 @@ func initFlags() {
 	// Logging
 	Server.Flags().StringVar(&c.Log.Format, "log-format", "text", "Log format text or json")
 	Server.Flags().StringVar(&c.Log.Level, "log-level", "info", "Log level debug, info, warning, error, fatal or panic")
+	Server.Flags().StringVar(&c.Log.LevelFieldName, "log-level-fieldname", "@level", "Log level fieldname for json format")
+
 
 	// Connect through Socks5 or HTTP CONNECT to Kafka
 	Server.Flags().StringVar(&c.ForwardProxy.Url, "forward-proxy", "", "URL of the forward proxy. Supported schemas are socks5 and http")
@@ -433,7 +435,7 @@ func SetLogger() {
 		formatter := &logrus.JSONFormatter{
 			FieldMap: logrus.FieldMap{
 				logrus.FieldKeyTime:  "@timestamp",
-				logrus.FieldKeyLevel: "@level",
+				logrus.FieldKeyLevel: c.Log.LevelFieldName,
 				logrus.FieldKeyMsg:   "@message",
 			},
 			TimestampFormat: time.RFC3339,

--- a/config/config.go
+++ b/config/config.go
@@ -38,8 +38,9 @@ type Config struct {
 		Enabled       bool
 	}
 	Log struct {
-		Format string
-		Level  string
+		Format         string
+		Level          string
+		LevelFieldName string
 	}
 	Proxy struct {
 		DefaultListenerIP       string


### PR DESCRIPTION
This makes the level field name configurable, which is helpful for services that have pre-configured log parsing (e.g. GKE wants "severity" [1]).


[1] https://cloud.google.com/monitoring/kubernetes-engine/legacy-stackdriver/logging#best_practices