### PR TITLE
Add the ability to have slightly more deterministic ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See:
           --default-listener-ip string                     Default listener IP (default "127.0.0.1")
           --dial-address-mapping stringArray               Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment
           --dynamic-listeners-disable                      Disable dynamic listeners.
+          --dynamic-sequential-min-port int                If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.
           --external-server-mapping stringArray            Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started
           --forbidden-api-keys intSlice                    Forbidden Kafka request types. The restriction should prevent some Kafka operations e.g. 20 - DeleteTopics
           --forward-proxy string                           URL of the forward proxy. Supported schemas are socks5 and http

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -87,6 +87,7 @@ func initFlags() {
 	Server.Flags().StringArrayVar(&externalServersMapping, "external-server-mapping", []string{}, "Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started")
 	Server.Flags().StringArrayVar(&dialAddressMapping, "dial-address-mapping", []string{}, "Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment")
 	Server.Flags().BoolVar(&c.Proxy.DisableDynamicListeners, "dynamic-listeners-disable", false, "Disable dynamic listeners.")
+	Server.Flags().IntVar(&c.Proxy.DynamicSequentialMinPort, "dynamic-sequential-min-port", 0, "If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.")
 
 	Server.Flags().IntVar(&c.Proxy.RequestBufferSize, "proxy-request-buffer-size", 4096, "Request buffer size pro tcp connection")
 	Server.Flags().IntVar(&c.Proxy.ResponseBufferSize, "proxy-response-buffer-size", 4096, "Response buffer size pro tcp connection")

--- a/config/config.go
+++ b/config/config.go
@@ -47,16 +47,17 @@ type Config struct {
 		LevelFieldName string
 	}
 	Proxy struct {
-		DefaultListenerIP       string
-		BootstrapServers        []ListenerConfig
-		ExternalServers         []ListenerConfig
-		DialAddressMappings     []DialAddressMapping
-		DisableDynamicListeners bool
-		RequestBufferSize       int
-		ResponseBufferSize      int
-		ListenerReadBufferSize  int // SO_RCVBUF
-		ListenerWriteBufferSize int // SO_SNDBUF
-		ListenerKeepAlive       time.Duration
+		DefaultListenerIP        string
+		BootstrapServers         []ListenerConfig
+		ExternalServers          []ListenerConfig
+		DialAddressMappings      []DialAddressMapping
+		DisableDynamicListeners  bool
+		DynamicSequentialMinPort int
+		RequestBufferSize        int
+		ResponseBufferSize       int
+		ListenerReadBufferSize   int // SO_RCVBUF
+		ListenerWriteBufferSize  int // SO_SNDBUF
+		ListenerKeepAlive        time.Duration
 
 		TLS struct {
 			Enable                   bool


### PR DESCRIPTION
If you're using dynamic listeners, it becomes very difficult to forward the right ports from kubernetes.

This change allows the ports to be sequential, so you can always pick a range of ports and forward them all without worrying about how many brokers we exactly have.