### PR TITLE
Implement same client cert check feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ Session.vim
 *~
 # Auto-generated tag files
 tags
+
+#IntelliJ
+kafka-proxy.iml
+vendor/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,6 +75,32 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:a5200282cd07d920ad0499556b1e864401b6df768e90d38068cfbb313a0b763f"
+  name = "github.com/grepplabs/kafka-proxy"
+  packages = [
+    "cmd/kafka-proxy",
+    "cmd/tools",
+    "config",
+    "pkg/apis",
+    "pkg/libs/googleid",
+    "pkg/libs/googleid-info",
+    "pkg/libs/googleid-provider",
+    "pkg/libs/util",
+    "pkg/registry",
+    "plugin/local-auth/proto",
+    "plugin/local-auth/shared",
+    "plugin/token-info/proto",
+    "plugin/token-info/shared",
+    "plugin/token-provider/proto",
+    "plugin/token-provider/shared",
+    "proxy",
+    "proxy/protocol",
+  ]
+  pruneopts = "UT"
+  revision = "1072f207f43ebaaef8bfb9b62a983934efff2fa0"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   digest = "1:07671f8997086ed115824d1974507d2b147d1e0463675ea5dbf3be89b1c2c563"
   name = "github.com/hashicorp/errwrap"
@@ -533,6 +559,23 @@
     "github.com/elazarl/goproxy/ext/auth",
     "github.com/fsnotify/fsnotify",
     "github.com/golang/protobuf/proto",
+    "github.com/grepplabs/kafka-proxy/cmd/kafka-proxy",
+    "github.com/grepplabs/kafka-proxy/cmd/tools",
+    "github.com/grepplabs/kafka-proxy/config",
+    "github.com/grepplabs/kafka-proxy/pkg/apis",
+    "github.com/grepplabs/kafka-proxy/pkg/libs/googleid",
+    "github.com/grepplabs/kafka-proxy/pkg/libs/googleid-info",
+    "github.com/grepplabs/kafka-proxy/pkg/libs/googleid-provider",
+    "github.com/grepplabs/kafka-proxy/pkg/libs/util",
+    "github.com/grepplabs/kafka-proxy/pkg/registry",
+    "github.com/grepplabs/kafka-proxy/plugin/local-auth/proto",
+    "github.com/grepplabs/kafka-proxy/plugin/local-auth/shared",
+    "github.com/grepplabs/kafka-proxy/plugin/token-info/proto",
+    "github.com/grepplabs/kafka-proxy/plugin/token-info/shared",
+    "github.com/grepplabs/kafka-proxy/plugin/token-provider/proto",
+    "github.com/grepplabs/kafka-proxy/plugin/token-provider/shared",
+    "github.com/grepplabs/kafka-proxy/proxy",
+    "github.com/grepplabs/kafka-proxy/proxy/protocol",
     "github.com/hashicorp/go-hclog",
     "github.com/hashicorp/go-multierror",
     "github.com/hashicorp/go-plugin",

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See:
           --tls-client-key-password string                 Password to decrypt rsa private key
           --tls-enable                                     Whether or not to use TLS when connecting to the broker
           --tls-insecure-skip-verify                       It controls whether a client verifies the server's certificate chain and host name
+          --same-client-cert-enable                        Use only when mutual TLS is enabled on proxy and broker. It controls whether a proxy validates if proxy client certificate matches brokers client cert (tls-client-cert-file)
 
 ### Usage example
 	
@@ -209,6 +210,22 @@ SASL authentication is performed by the proxy. SASL authentication is enabled on
                              --auth-local-param "--claim-sub=alice" \
                              --auth-local-param "--claim-sub=bob" \
                              --bootstrap-server-mapping "192.168.99.100:32400,127.0.0.1:32400"
+                             
+### Same client certificate check enabled example
+
+Validate that client certificate used by proxy client is exactly the same as client certificate in authentication initiated by proxy 
+                       
+    kafka-proxy server --bootstrap-server-mapping "kafka-0.grepplabs.com:9093,0.0.0.0:32399" \
+       --tls-enable \
+       --tls-client-cert-file client.crt \
+       --tls-client-key-file client.pem \
+       --tls-client-key-password changeit \
+       --proxy-listener-tls-enable \
+       --proxy-listener-key-file server.pem \
+       --proxy-listener-cert-file server.crt \
+       --proxy-listener-key-password changeit \
+       --proxy-listener-ca-chain-cert-file ca.crt \
+       --same-client-cert-enable
 
 ### Kafka Gateway example
 

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -148,6 +148,9 @@ func initFlags() {
 	Server.Flags().StringVar(&c.Kafka.TLS.ClientKeyPassword, "tls-client-key-password", "", "Password to decrypt rsa private key")
 	Server.Flags().StringVar(&c.Kafka.TLS.CAChainCertFile, "tls-ca-chain-cert-file", "", "PEM encoded CA's certificate file")
 
+	//Same TLS client cert
+	Server.Flags().BoolVar(&c.Kafka.TLS.SameClientCertEnable, "same-client-cert-enable", false, "Use only when mutual TLS is enabled on proxy and broker. It controls whether a proxy validates if proxy client certificate matches brokers client cert (tls-client-cert-file)")
+
 	// SASL by Proxy
 	Server.Flags().BoolVar(&c.Kafka.SASL.Enable, "sasl-enable", false, "Connect using SASL")
 	Server.Flags().StringVar(&c.Kafka.SASL.Username, "sasl-username", "", "SASL user name")

--- a/config/config.go
+++ b/config/config.go
@@ -113,12 +113,13 @@ type Config struct {
 		ConnectionWriteBufferSize int // SO_SNDBUF
 
 		TLS struct {
-			Enable             bool
-			InsecureSkipVerify bool
-			ClientCertFile     string
-			ClientKeyFile      string
-			ClientKeyPassword  string
-			CAChainCertFile    string
+			Enable               bool
+			InsecureSkipVerify   bool
+			ClientCertFile       string
+			ClientKeyFile        string
+			ClientKeyPassword    string
+			CAChainCertFile      string
+			SameClientCertEnable bool
 		}
 
 		SASL struct {
@@ -314,6 +315,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Proxy.TLS.Enable && (c.Proxy.TLS.ListenerKeyFile == "" || c.Proxy.TLS.ListenerCertFile == "") {
 		return errors.New("ListenerKeyFile and ListenerCertFile are required when Proxy TLS is enabled")
+	}
+	if c.Kafka.TLS.SameClientCertEnable && (!c.Kafka.TLS.Enable || c.Kafka.TLS.ClientCertFile == "" || !c.Proxy.TLS.Enable) {
+		return errors.New("ClientCertFile is required on Kafka TLS and TLS must be enabled on both Proxy and Kafka connections when SameClientCertEnable is enabled")
 	}
 	if c.Auth.Local.Enable && c.Auth.Local.Command == "" {
 		return errors.New("Command is required when Auth.Local.Enable is enabled")

--- a/proxy/tls.go
+++ b/proxy/tls.go
@@ -8,7 +8,9 @@ import (
 	"github.com/klauspost/cpuid"
 	"github.com/pkg/errors"
 	"io/ioutil"
+	"net"
 	"strings"
+	"time"
 )
 
 var (
@@ -58,6 +60,8 @@ var (
 		"ECDHE-RSA-3DES-EDE-CBC-SHA":         tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
 		"RSA-3DES-EDE-CBC-SHA":               tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 	}
+
+	zeroTime = time.Time{}
 )
 
 func newTLSListenerConfig(conf *config.Config) (*tls.Config, error) {
@@ -224,4 +228,80 @@ func decryptPEM(pemData []byte, password string) ([]byte, error) {
 		return pem.EncodeToMemory(block), nil
 	}
 	return pemData, nil
+}
+
+func parseCertificate(certFile string) (*x509.Certificate, error) {
+
+	content, readErr := ioutil.ReadFile(certFile)
+
+	if readErr != nil {
+		return nil, errors.Errorf("Failed to read file from location '%s'", certFile)
+	}
+
+	block, _ := pem.Decode(content)
+
+	cert, parseErr := x509.ParseCertificate(block.Bytes)
+
+	if parseErr != nil {
+		return nil, errors.Errorf("Failed to parse certificate file from location '%s'", certFile)
+	}
+
+	return cert, nil
+}
+
+func handshakeAsTLSAndValidateClientCert(conn net.Conn, expectedCert *x509.Certificate, handshakeTimeout time.Duration) error {
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return errors.New("Unable to cast connection to TLS when validating client cert")
+	}
+
+	err := handshakeTLSConn(tlsConn, handshakeTimeout)
+	if err != nil {
+		return err
+	}
+
+	actualClientCert := filterClientCertificate(tlsConn.ConnectionState().PeerCertificates)
+
+	result := validateClientCert(actualClientCert, expectedCert)
+
+	return result
+}
+
+func handshakeTLSConn(tlsConn *tls.Conn, timeout time.Duration) error {
+	err := tlsConn.SetDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return errors.Errorf("Failed to set deadline with handshake timeout in seconds %f on connection: %v", timeout.Seconds(), err)
+	}
+
+	err = tlsConn.Handshake()
+	if err != nil {
+		return errors.Errorf("TLS handshake failed when exchanging client certificates: %v", err)
+	}
+
+	err = tlsConn.SetDeadline(zeroTime)
+	if err != nil {
+		return errors.Errorf("Failed to reset deadline on connection: %v", err)
+	}
+
+	return err
+}
+
+func filterClientCertificate(peerCertificates []*x509.Certificate) *x509.Certificate {
+	for _, v := range peerCertificates {
+		if !v.IsCA {
+			return v
+		}
+	}
+	return nil
+}
+
+func validateClientCert(actualClientCert *x509.Certificate, expectedCert *x509.Certificate) error {
+	if actualClientCert == nil {
+		return errors.New("Client cert not found in TLS connection")
+	}
+
+	if !actualClientCert.Equal(expectedCert) {
+		return errors.New("Client cert sent by proxy client does not match brokers client cert (tls-client-cert-file)")
+	}
+	return nil
 }

--- a/proxy/tls_test.go
+++ b/proxy/tls_test.go
@@ -61,7 +61,7 @@ func TestTLSUnknownAuthorityNoCAChainCert(t *testing.T) {
 	c.Proxy.TLS.ListenerCertFile = bundle.ServerCert.Name()
 	c.Proxy.TLS.ListenerKeyFile = bundle.ServerKey.Name()
 
-	_, _, _, err := makeTLSPipe(c)
+	_, _, _, err := makeTLSPipe(c, nil)
 	a.EqualError(err, "x509: certificate signed by unknown authority")
 }
 
@@ -80,7 +80,7 @@ func TestTLSUnknownAuthorityWrongCAChainCert(t *testing.T) {
 	// different bundle -> incorrect cert
 	c.Kafka.TLS.CAChainCertFile = bundle2.ServerCert.Name()
 
-	_, _, _, err := makeTLSPipe(c)
+	_, _, _, err := makeTLSPipe(c, nil)
 	a.EqualError(err, "x509: certificate signed by unknown authority")
 }
 
@@ -95,7 +95,7 @@ func TestTLSInsecureSkipVerify(t *testing.T) {
 	c.Proxy.TLS.ListenerKeyFile = bundle.ServerKey.Name()
 	c.Kafka.TLS.InsecureSkipVerify = true
 
-	c1, c2, stop, err := makeTLSPipe(c)
+	c1, c2, stop, err := makeTLSPipe(c, nil)
 	if err != nil {
 		a.FailNow(err.Error())
 	}
@@ -114,7 +114,7 @@ func TestTLSSelfSigned(t *testing.T) {
 	c.Proxy.TLS.ListenerKeyFile = bundle.ServerKey.Name()
 	c.Kafka.TLS.CAChainCertFile = bundle.ServerCert.Name()
 
-	c1, c2, stop, err := makeTLSPipe(c)
+	c1, c2, stop, err := makeTLSPipe(c, nil)
 	if err != nil {
 		a.FailNow(err.Error())
 	}
@@ -260,7 +260,7 @@ func TestTLSVerifyClientCertDifferentCAs(t *testing.T) {
 	c.Kafka.TLS.ClientCertFile = bundle2.ClientCert.Name()
 	c.Kafka.TLS.ClientKeyFile = bundle2.ClientKey.Name()
 
-	c1, c2, stop, err := makeTLSPipe(c)
+	c1, c2, stop, err := makeTLSPipe(c, nil)
 	if err != nil {
 		a.FailNow(err.Error())
 	}
@@ -283,7 +283,7 @@ func TestTLSVerifyClientCertSameCAs(t *testing.T) {
 	c.Kafka.TLS.ClientCertFile = bundle1.ClientCert.Name()
 	c.Kafka.TLS.ClientKeyFile = bundle1.ClientKey.Name()
 
-	c1, c2, stop, err := makeTLSPipe(c)
+	c1, c2, stop, err := makeTLSPipe(c, nil)
 	if err != nil {
 		a.FailNow(err.Error())
 	}
@@ -304,7 +304,7 @@ func TestTLSMissingClientCert(t *testing.T) {
 
 	c.Kafka.TLS.CAChainCertFile = bundle1.ServerCert.Name()
 
-	_, _, _, err := makeTLSPipe(c)
+	_, _, _, err := makeTLSPipe(c, nil)
 	a.NotNil(err)
 	a.Contains(err.Error(), "tls: client didn't provide a certificate")
 }
@@ -326,10 +326,88 @@ func TestTLSBadClientCert(t *testing.T) {
 	c.Kafka.TLS.CAChainCertFile = bundle1.ServerCert.Name()
 	c.Kafka.TLS.ClientCertFile = bundle2.ClientCert.Name()
 	c.Kafka.TLS.ClientKeyFile = bundle2.ClientKey.Name()
-	_, _, _, err := makeTLSPipe(c)
+	_, _, _, err := makeTLSPipe(c, nil)
 
 	a.NotNil(err)
 	a.Contains(err.Error(), "tls: failed to verify client's certificate")
+}
+
+func TestTLSVerifySameClientCert(t *testing.T) {
+
+	sameCertToCompare := true
+	differentCertToCompare := false
+
+	bundle1 := NewCertsBundle()
+	defer bundle1.Close()
+
+	bundle2 := NewCertsBundle()
+	defer bundle2.Close()
+
+	t.Run("SameClientCertDisabledWithSameClientCerts", func(t *testing.T) {
+		c, clientCertFileToCheck := configWithCertToCompare(bundle1, bundle2, sameCertToCompare)
+		c.Kafka.TLS.SameClientCertEnable = false
+		successfulPingPong(t, c, clientCertFileToCheck)
+	})
+
+	t.Run("SameClientCertDisabledWithDifferentClientCerts", func(t *testing.T) {
+		c, clientCertFileToCheck := configWithCertToCompare(bundle1, bundle2, differentCertToCompare)
+		c.Kafka.TLS.SameClientCertEnable = false
+		successfulPingPong(t, c, clientCertFileToCheck)
+	})
+
+	t.Run("SameClientCertEnabledWithSameClientCerts", func(t *testing.T) {
+		c, clientCertFileToCheck := configWithCertToCompare(bundle1, bundle2, sameCertToCompare)
+		c.Kafka.TLS.SameClientCertEnable = true
+		successfulPingPong(t, c, clientCertFileToCheck)
+	})
+
+	t.Run("SameClientCertEnabledWithDifferentClientCerts", func(t *testing.T) {
+		c, clientCertFileToCheck := configWithCertToCompare(bundle1, bundle2, differentCertToCompare)
+		c.Kafka.TLS.SameClientCertEnable = true
+		pipelineSetupFailure(t, c, clientCertFileToCheck, "Client cert sent by proxy client does not match brokers client cert (tls-client-cert-file)")
+	})
+}
+
+func configWithCertToCompare(bundle1 *CertsBundle, bundle2 *CertsBundle, sameCertToCompare bool) (*config.Config, string) {
+	c := new(config.Config)
+
+	c.Proxy.TLS.ListenerCertFile = bundle1.ServerCert.Name()
+	c.Proxy.TLS.ListenerKeyFile = bundle1.ServerKey.Name()
+	c.Proxy.TLS.CAChainCertFile = bundle2.CACert.Name() // client CA
+
+	c.Kafka.TLS.CAChainCertFile = bundle1.ServerCert.Name()
+	c.Kafka.TLS.ClientCertFile = bundle2.ClientCert.Name()
+	c.Kafka.TLS.ClientKeyFile = bundle2.ClientKey.Name() //client cert
+
+	if sameCertToCompare {
+		return c, bundle2.ClientCert.Name()
+	}
+
+	return c, bundle1.ClientCert.Name()
+}
+
+func successfulPingPong(t *testing.T, conf *config.Config, clientCertFileToCheck string) {
+	a := assert.New(t)
+
+	clientCertToCheck, _ := parseCertificate(clientCertFileToCheck)
+
+	c1, c2, stop, err := makeTLSPipe(conf, clientCertToCheck)
+	if err != nil {
+		a.FailNow(err.Error())
+	}
+	defer stop()
+	pingPong(t, c1, c2)
+}
+
+func pipelineSetupFailure(t *testing.T, conf *config.Config, clientCertFileToCheck string, expectedErrMsg string) {
+	a := assert.New(t)
+
+	expectedClientCert, _ := parseCertificate(clientCertFileToCheck)
+
+	_, _, _, err := makeTLSPipe(conf, expectedClientCert)
+
+	a.NotNil(err)
+	a.Equal(err.Error(), expectedErrMsg)
 }
 
 func pingPong(t *testing.T, c1, c2 net.Conn) {


### PR DESCRIPTION
Implement same client cert check functionality as discussed in https://github.com/grepplabs/kafka-proxy/issues/37

Major changes:
1) New flag --same-client-cert-enable that enables check set to false by default (backwards compatibility)
2) Extend config validation to require TLS on both sides and client cert on Kafka connection when new flag is set
3) Feature implementation in client that includes handshake (with timeout with same value as dial timeout), retrieving client certificate from proxy client connection and validating that it matches configured Kafka client cert
3) Tests for config validation and flag handling (both success and failure scenarios)
4) Include flag description and feature sample in readme file