### PR TITLE
Advertised address for dynamic listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See:
           --debug-listen-address string                    Debug listen address (default "0.0.0.0:6060")
           --default-listener-ip string                     Default listener IP (default "127.0.0.1")
           --dial-address-mapping stringArray               Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment
+          --dynamic-advertised-listener                    Advertised address for dynamic listeners (default "127.0.0.1")
           --dynamic-listeners-disable                      Disable dynamic listeners.
           --dynamic-sequential-min-port int                If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.
           --external-server-mapping stringArray            Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -83,6 +83,7 @@ func init() {
 func initFlags() {
 	// proxy
 	Server.Flags().StringVar(&c.Proxy.DefaultListenerIP, "default-listener-ip", "127.0.0.1", "Default listener IP")
+	Server.Flags().StringVar(&c.Proxy.DynamicAdvertisedListener, "dynamic-advertised-listener", "127.0.0.1", "Advertised address for dynamic listeners")
 	Server.Flags().StringArrayVar(&bootstrapServersMapping, "bootstrap-server-mapping", []string{}, "Mapping of Kafka bootstrap server address to local address (host:port,host:port(,advhost:advport))")
 	Server.Flags().StringArrayVar(&externalServersMapping, "external-server-mapping", []string{}, "Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started")
 	Server.Flags().StringArrayVar(&dialAddressMapping, "dial-address-mapping", []string{}, "Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment")

--- a/config/config.go
+++ b/config/config.go
@@ -49,17 +49,18 @@ type Config struct {
 		MsgFiledName   string
 	}
 	Proxy struct {
-		DefaultListenerIP        string
-		BootstrapServers         []ListenerConfig
-		ExternalServers          []ListenerConfig
-		DialAddressMappings      []DialAddressMapping
-		DisableDynamicListeners  bool
-		DynamicSequentialMinPort int
-		RequestBufferSize        int
-		ResponseBufferSize       int
-		ListenerReadBufferSize   int // SO_RCVBUF
-		ListenerWriteBufferSize  int // SO_SNDBUF
-		ListenerKeepAlive        time.Duration
+		DefaultListenerIP         string
+		BootstrapServers          []ListenerConfig
+		ExternalServers           []ListenerConfig
+		DialAddressMappings       []DialAddressMapping
+		DisableDynamicListeners   bool
+		DynamicAdvertisedListener string
+		DynamicSequentialMinPort  int
+		RequestBufferSize         int
+		ResponseBufferSize        int
+		ListenerReadBufferSize    int // SO_RCVBUF
+		ListenerWriteBufferSize   int // SO_SNDBUF
+		ListenerKeepAlive         time.Duration
 
 		TLS struct {
 			Enable                   bool
@@ -251,6 +252,7 @@ func NewConfig() *Config {
 	c.Http.HealthPath = "/health"
 
 	c.Proxy.DefaultListenerIP = "127.0.0.1"
+	c.Proxy.DynamicAdvertisedListener = "127.0.0.1"
 	c.Proxy.DisableDynamicListeners = false
 	c.Proxy.RequestBufferSize = 4096
 	c.Proxy.ResponseBufferSize = 4096


### PR DESCRIPTION
If Kafka-proxy is not run as a local side-car but on a remote server to proxy a remote Kafka Cluster, the dynamic listeners for the discovered brokers from the metadata are not resolvable. We can side-step this issue by configuring a  bootstrap-server-mapping for every kafka broker in the cluster we are proxying, but that feels a bit too manual and requires foreknowledge of how many brokers are in the cluster. Instead it seems simple enough to add another flag that sets the advertised address for any dynamic listeners.

Consider:
```
kafka-proxy server --dynamic-listeners-disable \
  --bootstrap-server-mapping remote-server:9092,0.0.0.0:9092,proxy-server:9092 \
  --bootstrap-server-mapping remote-broker1:9092,0.0.0.0:9093,proxy-server:9093 \
  --bootstrap-server-mapping remote-broker2:9092,0.0.0.0:9094,proxy-server:9094 \
  ...
```
vs.
```
kafka-proxy server --bootstrap-server-mapping remote-server:9092,0.0.0.0:9092,proxy-server:9092 \
  --default-listener-ip 0.0.0.0 \
  --dynamic-sequential-min-port 9093 \
  --dynamic-advertised-listener proxy-server 
```
Let me know if this would be useful, or if I'm missing something on how kafka-proxy is intended to be used. 