### PR TITLE
Changed auth-ldap plugin to optionally retrieve the user dn from LDAP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,17 @@ SASL authentication is performed by the proxy. SASL authentication is enabled on
                              --auth-local-param "--user-attr=uid" \
                              --bootstrap-server-mapping "192.168.99.100:32400,127.0.0.1:32400"
 
+    # Same as above, but retrieve true User DN from LDAP using --user-dn parameter as base dn for search 
+    make clean build plugin.auth-ldap && build/kafka-proxy server \
+                             --auth-local-enable \
+                             --auth-local-command build/auth-ldap \
+                             --auth-local-param "--url=ldaps://ldap.example.com:636" \
+                             --auth-local-param "--user-dn=cn=users,dc=exemple,dc=com" \
+                             --auth-local-param "--lookup-user-dn" \
+                             --auth-local-param "--object-class=organizationalPerson" \   # Search only objects of this class
+                             --auth-local-param "--user-attr=uid" \
+                             --bootstrap-server-mapping "192.168.99.100:32400,127.0.0.1:32400"
+
     make clean build plugin.unsecured-jwt-info && build/kafka-proxy server \
                              --auth-local-enable \
                              --auth-local-command build/unsecured-jwt-info \


### PR DESCRIPTION
… instead of constructing it locally. 

Our LDAP uses User DNs that cannot be constructed from uid and a set of fixed attributs. Threrefore, I added code (and flags) to enable auth-ldap to retrieve the user db from LDAP itself.

The following flags were added to auth-ldap (see also README.md:

--lookup-user-dn Lookup the user dn instead of construction it locally. The search uses the value of --user-dn als base dn
and the value of --user-attr as search attrribute

--object-class  The LDAP Object class to search. 

The function getUserBindDNFromLDAP(...) performs the search  

I'm no ldap expert, so I guess is would be good to take a closer look at my query filter 