### PR TITLE
Implement client certificate subject validation

### DIFF
--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+
 	"github.com/grepplabs/kafka-proxy/config"
 	"github.com/grepplabs/kafka-proxy/proxy"
 	"github.com/oklog/run"
@@ -20,13 +21,14 @@ import (
 	"time"
 
 	"errors"
+	"strings"
+
 	"github.com/grepplabs/kafka-proxy/pkg/apis"
 	localauth "github.com/grepplabs/kafka-proxy/plugin/local-auth/shared"
 	tokeninfo "github.com/grepplabs/kafka-proxy/plugin/token-info/shared"
 	tokenprovider "github.com/grepplabs/kafka-proxy/plugin/token-provider/shared"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
-	"strings"
 
 	"github.com/grepplabs/kafka-proxy/pkg/registry"
 	// built-in plugins
@@ -104,6 +106,14 @@ func initFlags() {
 	Server.Flags().StringVar(&c.Proxy.TLS.CAChainCertFile, "proxy-listener-ca-chain-cert-file", "", "PEM encoded CA's certificate file. If provided, client certificate is required and verified")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ListenerCipherSuites, "proxy-listener-cipher-suites", []string{}, "List of supported cipher suites")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ListenerCurvePreferences, "proxy-listener-curve-preferences", []string{}, "List of curve preferences")
+
+	Server.Flags().BoolVar(&c.Proxy.TLS.ClientCert.ValidateSubject, "proxy-listener-tls-client-cert-validate-subject", false, "Whether to validate client certificate subject")
+	Server.Flags().StringVar(&c.Proxy.TLS.ClientCert.Subject.CommonName, "proxy-listener-tls-client-cert-subject-common-name", "", "Required client certificate subject common name")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Country, "proxy-listener-tls-required-client-subject-country", []string{}, "Required client certificate subject country")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Province, "proxy-listener-tls-required-client-subject-province", []string{}, "Required client certificate subject province")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Locality, "proxy-listener-tls-required-client-subject-locality", []string{}, "Required client certificate subject locality")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Organization, "proxy-listener-tls-required-client-subject-organization", []string{}, "Required client certificate subject organization")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.OrganizationalUnit, "proxy-listener-tls-required-client-subject-organizational-unit", []string{}, "Required client certificate subject organizational unit")
 
 	// local authentication plugin
 	Server.Flags().BoolVar(&c.Auth.Local.Enable, "auth-local-enable", false, "Enable local SASL/PLAIN authentication performed by listener - SASL handshake will not be passed to kafka brokers")

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/grepplabs/kafka-proxy/pkg/libs/util"
-	"github.com/pkg/errors"
 	"net"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/grepplabs/kafka-proxy/pkg/libs/util"
+	"github.com/pkg/errors"
 )
 
 const defaultClientID = "kafka-proxy"
@@ -70,6 +71,17 @@ type Config struct {
 			CAChainCertFile          string
 			ListenerCipherSuites     []string
 			ListenerCurvePreferences []string
+			ClientCert               struct {
+				ValidateSubject bool
+				Subject         struct {
+					CommonName         string
+					Country            []string
+					Province           []string
+					Locality           []string
+					Organization       []string
+					OrganizationalUnit []string
+				}
+			}
 		}
 	}
 	Auth struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -3,11 +3,12 @@ package proxy
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
+	"sync"
+
 	"github.com/grepplabs/kafka-proxy/config"
 	"github.com/grepplabs/kafka-proxy/pkg/libs/util"
 	"github.com/sirupsen/logrus"
-	"net"
-	"sync"
 )
 
 type ListenFunc func(cfg config.ListenerConfig) (l net.Listener, err error)


### PR DESCRIPTION
This PR implements client certificate subject validation. The DN fields selected for this initial version are somewhat arbitrary but most likely the most common. This allows configuring the proxy TLS to validate the client cert subject, the Kafka Proxy operator can require specific subject to be present and contain specific values.

I have opted in for a flag per subject field to prevent requiring the user to follow any arbitrary string format. Additionally, all or none of the DN fields are explicitly required.

In a multi-tenant environment, the tenant has the ability to request certificates from a CA. The usual setup is:

```
Root CA -> Intermediate -> | -> Server certificate Tenant A
                           | -> Client certificate Tenant A
                           | -> Server certificate Tenant B
                           | -> Client certificate Tenant B
```

For security reasons, the CA operator does not allow tenants to issue an intermediate from the intermediate, this would require that the second stage intermediate allows certificate signing. With such setup, the user of Client certificate Tenant B can connect to Server Tenant A. Being able to additionally validate the subject adds a layer of security on the TLS level.