### PR TITLE
Make flags for client certificate validation consistent. Document.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ See:
           --tls-insecure-skip-verify                       It controls whether a client verifies the server's certificate chain and host name
           --tls-same-client-cert-enable                    Use only when mutual TLS is enabled on proxy and broker. It controls whether a proxy validates if proxy client certificate exactly matches brokers client cert (tls-client-cert-file)
 
+          --proxy-listener-tls-client-cert-validate-subject bool                        Whether to validate client certificate subject (default false)
+	        --proxy-listener-tls-required-client-subject-common-name string               Required client certificate subject common name
+          --proxy-listener-tls-required-client-subject-country stringArray              Required client certificate subject country
+	        --proxy-listener-tls-required-client-subject-province stringArray             Required client certificate subject province
+	        --proxy-listener-tls-required-client-subject-locality stringArray             Required client certificate subject locality
+	        --proxy-listener-tls-required-client-subject-organization stringArray         Required client certificate subject organization
+	        --proxy-listener-tls-required-client-subject-organizational-unit stringArray  Required client certificate subject organizational unit
+
 ### Usage example
 	
 	kafka-proxy server --bootstrap-server-mapping "192.168.99.100:32400,0.0.0.0:32399"
@@ -310,6 +318,29 @@ Connect through test HTTP Proxy server using CONNECT method
                        --bootstrap-server-mapping "kafka-1.grepplabs.com:9092,127.0.0.1:32501" \
                        --bootstrap-server-mapping "kafka-2.grepplabs.com:9092,127.0.0.1:32502" \
                        --forward-proxy http://my-proxy-user:my-proxy-password@localhost:3128
+```
+
+### Validating client certificate DN
+
+Sometimes it might be necessary to not only validate that the client certificate is valid but also that the client certificate DN is issued for a concrete use case. This can be achieved using the following set of arguments:
+
+```
+--proxy-listener-tls-client-cert-validate-subject bool                        Whether to validate client certificate subject (default false)
+--proxy-listener-tls-required-client-subject-common-name string               Required client certificate subject common name
+--proxy-listener-tls-required-client-subject-country stringArray              Required client certificate subject country
+--proxy-listener-tls-required-client-subject-province stringArray             Required client certificate subject province
+--proxy-listener-tls-required-client-subject-locality stringArray             Required client certificate subject locality
+--proxy-listener-tls-required-client-subject-organization stringArray         Required client certificate subject organization
+--proxy-listener-tls-required-client-subject-organizational-unit stringArray  Required client certificate subject organizational unit
+```
+
+By setting `--proxy-listener-tls-client-cert-validate-subject true`, Kafka Proxy will inspect client certificate DN fields for the expected values set with the `--proxy-listener-tls-required-client-*` arguments. The matches are always exact and used together, fo all non empty values. For example, to allow a valid certificate for `country=DE` and `organization=grepplabs`, configure Kafka Proxy in the following way:
+
+```
+    kafka-proxy server \
+      --proxy-listener-tls-client-cert-validate-subject true \
+      --proxy-listener-tls-required-client-subject-country DE \
+      --proxy-listener-tls-required-client-subject-organization grepplabs
 ```
 
 ### Kubernetes sidecar container example

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -108,7 +108,7 @@ func initFlags() {
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ListenerCurvePreferences, "proxy-listener-curve-preferences", []string{}, "List of curve preferences")
 
 	Server.Flags().BoolVar(&c.Proxy.TLS.ClientCert.ValidateSubject, "proxy-listener-tls-client-cert-validate-subject", false, "Whether to validate client certificate subject")
-	Server.Flags().StringVar(&c.Proxy.TLS.ClientCert.Subject.CommonName, "proxy-listener-tls-client-cert-subject-common-name", "", "Required client certificate subject common name")
+	Server.Flags().StringVar(&c.Proxy.TLS.ClientCert.Subject.CommonName, "proxy-listener-tls-required-client-subject-common-name", "", "Required client certificate subject common name")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Country, "proxy-listener-tls-required-client-subject-country", []string{}, "Required client certificate subject country")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Province, "proxy-listener-tls-required-client-subject-province", []string{}, "Required client certificate subject province")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subject.Locality, "proxy-listener-tls-required-client-subject-locality", []string{}, "Required client certificate subject locality")


### PR DESCRIPTION
Hi @everesio. I have made a mistake in the original PR for this feature where the flags for the client certificate subject validation were not consistent. This PR fixes the problem and also documents the usage.