### PR TITLE
Fix getStringArray, in that method, when length was -1 it was returni…

### DIFF
--- a/proxy/protocol/real_decoder.go
+++ b/proxy/protocol/real_decoder.go
@@ -250,19 +250,14 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 }
 
 func (rd *realDecoder) getStringArray() ([]string, error) {
-	if rd.remaining() < 4 {
-		rd.off = len(rd.raw)
-		return nil, ErrInsufficientData
-	}
-	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
-	rd.off += 4
+	n, err := rd.getArrayLength()
 
-	if n == 0 {
+	if err != nil {
+		return nil, err
+	}
+
+	if n == -1 {
 		return nil, nil
-	}
-
-	if n < 0 {
-		return nil, errInvalidArrayLength
 	}
 
 	ret := make([]string, n)


### PR DESCRIPTION
…ng length of uint
- when i was making metadata request for all topics, getting array was returning out of memory exception, because getting size of array in case it was null, returned instead of -1 number of size max uint32 4294967295
- https://golang.org/ref/spec#Numeric_types
int=uint
intXX=signed int
- as i check problem may araise also elsewhere e.g. getStringLength, getVarintStringLength, in fact -1 conditions there should be unreachable