### PR TITLE
Additional changes to the multiple client cert validation

### DIFF
--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -107,7 +107,7 @@ func initFlags() {
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ListenerCipherSuites, "proxy-listener-cipher-suites", []string{}, "List of supported cipher suites")
 	Server.Flags().StringSliceVar(&c.Proxy.TLS.ListenerCurvePreferences, "proxy-listener-curve-preferences", []string{}, "List of curve preferences")
 
-	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subjects, "proxy-listener-tls-required-client-subject", []string{""}, "Required client certificate subject common name; example; s:/CN=[value]/C=[state]/C=[DE,PL] or r:/CN=[^val.{2}$]/C=[state]/C=[DE,PL]; check manual for more details")
+	Server.Flags().StringSliceVar(&c.Proxy.TLS.ClientCert.Subjects, "proxy-listener-tls-required-client-subject", []string{}, "Required client certificate subject common name; example; s:/CN=[value]/C=[state]/C=[DE,PL] or r:/CN=[^val.{2}$]/C=[state]/C=[DE,PL]; check manual for more details")
 
 	// local authentication plugin
 	Server.Flags().BoolVar(&c.Auth.Local.Enable, "auth-local-enable", false, "Enable local SASL/PLAIN authentication performed by listener - SASL handshake will not be passed to kafka brokers")


### PR DESCRIPTION
Hey @everesio, here are some additional little changes to the multiple client certs validation.

- Fix flag default: empty list instead of single empty string: important, without this, kafka proxy is falling over every time when started from command line because the single empty string riggers the parser to start working but it fails validation because it is obviously not a valid client cert subject

Additionally:

- Don't switch on errors, use if / else
- Unquote single quoted arguments
