### PR TITLE
feat: change 0.0.0.0 as default listener IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You can launch a kafka-proxy container with auth-ldap plugin for trying it out w
           --bootstrap-server-mapping stringArray                                         Mapping of Kafka bootstrap server address to local address (host:port,host:port(,advhost:advport))
           --debug-enable                                                                 Enable Debug endpoint
           --debug-listen-address string                                                  Debug listen address (default "0.0.0.0:6060")
-          --default-listener-ip string                                                   Default listener IP (default "127.0.0.1")
+          --default-listener-ip string                                                   Default listener IP (default "0.0.0.0")
           --dial-address-mapping stringArray                                             Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment
           --dynamic-advertised-listener string                                           Advertised address for dynamic listeners. If empty, default-listener-ip is used
           --dynamic-listeners-disable                                                    Disable dynamic listeners.

--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -84,7 +84,7 @@ func init() {
 
 func initFlags() {
 	// proxy
-	Server.Flags().StringVar(&c.Proxy.DefaultListenerIP, "default-listener-ip", "127.0.0.1", "Default listener IP")
+	Server.Flags().StringVar(&c.Proxy.DefaultListenerIP, "default-listener-ip", "0.0.0.0", "Default listener IP")
 	Server.Flags().StringVar(&c.Proxy.DynamicAdvertisedListener, "dynamic-advertised-listener", "", "Advertised address for dynamic listeners. If empty, default-listener-ip is used")
 	Server.Flags().StringArrayVar(&bootstrapServersMapping, "bootstrap-server-mapping", []string{}, "Mapping of Kafka bootstrap server address to local address (host:port,host:port(,advhost:advport))")
 	Server.Flags().StringArrayVar(&externalServersMapping, "external-server-mapping", []string{}, "Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started")

--- a/config/config.go
+++ b/config/config.go
@@ -258,7 +258,7 @@ func NewConfig() *Config {
 	c.Http.MetricsPath = "/metrics"
 	c.Http.HealthPath = "/health"
 
-	c.Proxy.DefaultListenerIP = "127.0.0.1"
+	c.Proxy.DefaultListenerIP = "0.0.0.0"
 	c.Proxy.DisableDynamicListeners = false
 	c.Proxy.RequestBufferSize = 4096
 	c.Proxy.ResponseBufferSize = 4096


### PR DESCRIPTION
Closes https://github.com/grepplabs/kafka-proxy/issues/89

The default value for the dynamic listeners IP (`default-listener-ip default`) was set to `127.0.0.1`.
`127.0.0.1` only binds to local network interface, meanwhile `0.0.0.0` to all network interfaces.
In that case, binding to `127.0.0.1` won't help for external calls as they won't reach the app. 

That's the reason why this PR changes the default IP to `0.0.0.0`.

 I didn't change any of the examples on the `README.md` since as far as I see they are still valid. However, feel free to request any extra change you think it should be put in place.