### PR TITLE
chore: fix docker tagging failing when branch contains slash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ notifications:
 script:
   - go build .
   - go test ./...
-  - export TAG=`if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then echo "latest"; else echo "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}"; fi`
+  - export TAG=`if [[ $TRAVIS_PULL_REQUEST == "false" ]] && [[ $TRAVIS_BRANCH == "master" ]]; then echo "latest"; else echo "${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}" | sed 's/\//_/g'; fi`
   - echo "docker tags $TAG and ${TAG}-all"
   - docker build --build-arg MAKE_TARGET="test build" -t $REPO:$TAG -f Dockerfile .
   - docker build --build-arg MAKE_TARGET="all" -t $REPO:${TAG}-all -f Dockerfile .


### PR DESCRIPTION
Docker builds are failing if tags contain slash characters (`/`). Tag names are generated from the git branch name, so it is not that uncommon to see `/` on the latest (i.e. git-flow pattern: `feat/xxx`, `fix/xxx`...).

This PR applies a simple `sed` command that replaces all `/` by `_` on the branch name value used for generating the Docker image tag name.