### PR TITLE
Run the container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,16 @@ RUN make -e GOARCH=${GOARCH} -e GOOS=${GOOS} clean ${MAKE_TARGET}
 
 FROM alpine:3.14
 RUN apk add --no-cache ca-certificates
+RUN adduser \
+        --disabled-password \
+        --gecos "" \
+        --home "/nonexistent" \
+        --shell "/sbin/nologin" \
+        --no-create-home \
+        kafka-proxy
 
 COPY --from=builder /go/src/github.com/grepplabs/kafka-proxy/build /opt/kafka-proxy/bin
+USER kafka-proxy
 ENTRYPOINT ["/opt/kafka-proxy/bin/kafka-proxy"]
 CMD ["--help"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine3.15 as builder
+FROM golang:1.20-alpine3.17 as builder
 RUN apk add alpine-sdk ca-certificates
 
 WORKDIR /go/src/github.com/grepplabs/kafka-proxy
@@ -9,7 +9,7 @@ ARG GOOS=linux
 ARG GOARCH=amd64
 RUN make -e GOARCH=${GOARCH} -e GOOS=${GOOS} clean ${MAKE_TARGET}
 
-FROM alpine:3.14
+FROM alpine:3.17
 RUN apk add --no-cache ca-certificates
 RUN adduser \
         --disabled-password \


### PR DESCRIPTION
Specify an unprivileged user to run kafka proxy. No need to run as the root user. Security fix.