### PR TITLE
fix: REAMDE docker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Docker images are available on [Docker Hub](https://hub.docker.com/r/grepplabs/k
 
 You can launch a kafka-proxy container for trying it out with
 
-    docker run --rm -p 30001-30003:30001-30003 grepplabs/kafka-proxy:v0.3.6 \
+    docker run --rm -p 30001-30003:30001-30003 grepplabs/kafka-proxy:0.3.6 \
               server \
             --bootstrap-server-mapping "localhost:19092,0.0.0.0:30001" \
             --bootstrap-server-mapping "localhost:29092,0.0.0.0:30002" \
@@ -88,7 +88,7 @@ Docker images with precompiled plugins located in `/opt/kafka-proxy/bin/` are ta
 
 You can launch a kafka-proxy container with auth-ldap plugin for trying it out with
 
-    docker run --rm -p 30001-30003:30001-30003 grepplabs/kafka-proxy:v0.3.6-all \
+    docker run --rm -p 30001-30003:30001-30003 grepplabs/kafka-proxy:0.3.6-all \
                   server \
                 --bootstrap-server-mapping "localhost:19092,0.0.0.0:30001" \
                 --bootstrap-server-mapping "localhost:29092,0.0.0.0:30002" \


### PR DESCRIPTION
The docker tags in the README.md file are wrong