### PR TITLE
Allow password to be specified via environment variable

### DIFF
--- a/cmd/plugin-auth-user/main.go
+++ b/cmd/plugin-auth-user/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"flag"
+	"os"
+
 	"github.com/grepplabs/kafka-proxy/plugin/local-auth/shared"
 	"github.com/hashicorp/go-plugin"
 	"github.com/sirupsen/logrus"
-	"os"
 )
+
+const EnvSaslPassword = "SASL_PASSWORD"
 
 type PasswordAuthenticator struct {
 	Username string
@@ -29,6 +32,11 @@ func main() {
 	passwordAuthenticator := &PasswordAuthenticator{}
 	flags := passwordAuthenticator.flagSet()
 	flags.Parse(os.Args[1:])
+
+	if passwordAuthenticator.Password == "" {
+		passwordAuthenticator.Password = os.Getenv(EnvSaslPassword)
+	}
+
 	if passwordAuthenticator.Username == "" || passwordAuthenticator.Password == "" {
 		logrus.Errorf("parameters username and password are required")
 		os.Exit(1)


### PR DESCRIPTION
This PR adds the ability to specify the expected password via environment variable for plugin-auth-local. Specifying passwords using command-line args can be insecure, as any user on the system is able to see process arguments. Allowing users to specify passwords via environment variables mitigates this risk, and tends to be a more idiomatic approach for container orchestrators like Kubernetes.