### PR TITLE
feat: Add support for deterministic listener ports (based on broker ID)

### DIFF
--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -89,6 +89,7 @@ func initFlags() {
 	Server.Flags().StringArrayVar(&bootstrapServersMapping, "bootstrap-server-mapping", []string{}, "Mapping of Kafka bootstrap server address to local address (host:port,host:port(,advhost:advport))")
 	Server.Flags().StringArrayVar(&externalServersMapping, "external-server-mapping", []string{}, "Mapping of Kafka server address to external address (host:port,host:port). A listener for the external address is not started")
 	Server.Flags().StringArrayVar(&dialAddressMapping, "dial-address-mapping", []string{}, "Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment")
+	Server.Flags().BoolVar(&c.Proxy.DeterministicListeners, "deterministic-listeners", false, "Enable deterministic listeners (listener port = min port + broker id).")
 	Server.Flags().BoolVar(&c.Proxy.DisableDynamicListeners, "dynamic-listeners-disable", false, "Disable dynamic listeners.")
 	Server.Flags().IntVar(&c.Proxy.DynamicSequentialMinPort, "dynamic-sequential-min-port", 0, "If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.")
 

--- a/config/config.go
+++ b/config/config.go
@@ -22,12 +22,16 @@ var (
 	Version = "unknown"
 )
 
-type NetAddressMappingFunc func(brokerHost string, brokerPort int32) (listenerHost string, listenerPort int32, err error)
+type NetAddressMappingFunc func(brokerHost string, brokerPort int32, brokerId int32) (listenerHost string, listenerPort int32, err error)
 
 type ListenerConfig struct {
 	BrokerAddress     string
 	ListenerAddress   string
 	AdvertisedAddress string
+}
+type IdListenerConfig struct {
+	BrokerAddress string
+	Listener      net.Listener
 }
 type DialAddressMapping struct {
 	SourceAddress      string
@@ -74,6 +78,7 @@ type Config struct {
 		DefaultListenerIP         string
 		BootstrapServers          []ListenerConfig
 		ExternalServers           []ListenerConfig
+		DeterministicListeners    bool
 		DialAddressMappings       []DialAddressMapping
 		DisableDynamicListeners   bool
 		DynamicAdvertisedListener string

--- a/proxy/processor_default_test.go
+++ b/proxy/processor_default_test.go
@@ -3,11 +3,12 @@ package proxy
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+	"time"
+
 	"github.com/grepplabs/kafka-proxy/proxy/protocol"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 func TestHandleRequest(t *testing.T) {
@@ -130,7 +131,7 @@ func TestHandleRequest(t *testing.T) {
 }
 
 func TestHandleResponse(t *testing.T) {
-	netAddressMappingFunc := func(brokerHost string, brokerPort int32) (listenerHost string, listenerPort int32, err error) {
+	netAddressMappingFunc := func(brokerHost string, brokerPort int32, brokerId int32) (listenerHost string, listenerPort int32, err error) {
 		if brokerHost == "localhost" {
 			switch brokerPort {
 			case 19092:

--- a/proxy/protocol/responses.go
+++ b/proxy/protocol/responses.go
@@ -14,6 +14,7 @@ const (
 	brokersKeyName = "brokers"
 	hostKeyName    = "host"
 	portKeyName    = "port"
+	nodeKeyName    = "node_id"
 
 	coordinatorKeyName  = "coordinator"
 	coordinatorsKeyName = "coordinators"
@@ -320,12 +321,16 @@ func modifyMetadataResponse(decodedStruct *Struct, fn config.NetAddressMappingFu
 		if !ok {
 			return errors.New("broker.port not found")
 		}
+		nodeId, ok := broker.Get(nodeKeyName).(int32)
+		if !ok {
+			return errors.New("broker.node_id not found")
+		}
 
 		if host == "" && port <= 0 {
 			continue
 		}
 
-		newHost, newPort, err := fn(host, port)
+		newHost, newPort, err := fn(host, port, nodeId)
 		if err != nil {
 			return err
 		}
@@ -383,12 +388,16 @@ func modifyCoordinator(decodedStruct *Struct, fn config.NetAddressMappingFunc) e
 	if !ok {
 		return errors.New("coordinator.port not found")
 	}
+	nodeId, ok := coordinator.Get(nodeKeyName).(int32)
+	if !ok {
+		return errors.New("coordinator.node_id not found")
+	}
 
 	if host == "" && port <= 0 {
 		return nil
 	}
 
-	newHost, newPort, err := fn(host, port)
+	newHost, newPort, err := fn(host, port, nodeId)
 	if err != nil {
 		return err
 	}

--- a/proxy/protocol/responses_test.go
+++ b/proxy/protocol/responses_test.go
@@ -3,10 +3,11 @@ package protocol
 import (
 	"encoding/hex"
 	"fmt"
-	"github.com/google/uuid"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
 
 	"github.com/grepplabs/kafka-proxy/config"
 	"github.com/pkg/errors"
@@ -20,7 +21,7 @@ var (
 		// topic_metadata
 		0x00, 0x00, 0x00, 0x00}
 
-	testResponseModifier = func(brokerHost string, brokerPort int32) (listenerHost string, listenerPort int32, err error) {
+	testResponseModifier = func(brokerHost string, brokerPort int32, brokerId int32) (listenerHost string, listenerPort int32, err error) {
 		if brokerHost == "localhost" && brokerPort == 51 {
 			return "myhost1", 34001, nil
 		} else if brokerHost == "google.com" && brokerPort == 273 {
@@ -31,7 +32,7 @@ var (
 		return "", 0, errors.New("unexpected data")
 	}
 
-	testResponseModifier2 = func(brokerHost string, brokerPort int32) (listenerHost string, listenerPort int32, err error) {
+	testResponseModifier2 = func(brokerHost string, brokerPort int32, brokerId int32) (listenerHost string, listenerPort int32, err error) {
 		if brokerHost == "localhost" && brokerPort == 19092 {
 			return "myhost1", 34001, nil
 		} else if brokerHost == "localhost" && brokerPort == 29092 {
@@ -374,7 +375,7 @@ func TestMetadataResponseV0(t *testing.T) {
 	a.Nil(err)
 	a.Equal(bytes, resp)
 
-	modifier, err := GetResponseModifier(apiKeyMetadata, apiVersion, func(brokerHost string, brokerPort int32) (listenerHost string, listenerPort int32, err error) {
+	modifier, err := GetResponseModifier(apiKeyMetadata, apiVersion, func(brokerHost string, brokerPort int32, brokerId int32) (listenerHost string, listenerPort int32, err error) {
 		if brokerHost == "localhost" && brokerPort == 51 {
 			return "azure.microsoft.com", 34001, nil
 		} else if brokerHost == "google.com" && brokerPort == 273 {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2,9 +2,10 @@ package proxy
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/grepplabs/kafka-proxy/config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestGetBrokerToListenerConfig(t *testing.T) {
@@ -24,7 +25,11 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
 			},
 			[]config.ListenerConfig{},
 			nil,
@@ -38,9 +43,21 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "kafka-proxy-0:32400"},
-				{"192.168.99.100:32401", "0.0.0.0:32401", "kafka-proxy-0:32401"},
-				{"192.168.99.100:32402", "0.0.0.0:32402", "kafka-proxy-0:32402"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32401",
+					ListenerAddress:   "0.0.0.0:32401",
+					AdvertisedAddress: "kafka-proxy-0:32401",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32402",
+					ListenerAddress:   "0.0.0.0:32402",
+					AdvertisedAddress: "kafka-proxy-0:32402",
+				},
 			},
 			[]config.ListenerConfig{},
 			nil,
@@ -64,8 +81,16 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32400"},
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
 			},
 			[]config.ListenerConfig{},
 			nil,
@@ -79,8 +104,16 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32400"},
-				{"192.168.99.100:32400", "0.0.0.0:32401", "0.0.0.0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32401",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
 			},
 			[]config.ListenerConfig{},
 			fmt.Errorf("bootstrap server mapping 192.168.99.100:32400 configured twice: {192.168.99.100:32400 0.0.0.0:32401 0.0.0.0:32400} and {192.168.99.100:32400 0.0.0.0:32400 0.0.0.0:32400}"),
@@ -88,8 +121,16 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32400"},
-				{"192.168.99.100:32400", "0.0.0.0:32400", "0.0.0.0:32401"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "0.0.0.0:32401",
+				},
 			},
 			[]config.ListenerConfig{},
 			fmt.Errorf("bootstrap server mapping 192.168.99.100:32400 configured twice: {192.168.99.100:32400 0.0.0.0:32400 0.0.0.0:32401} and {192.168.99.100:32400 0.0.0.0:32400 0.0.0.0:32400}"),
@@ -97,13 +138,31 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "kafka-proxy-0:32400"},
-				{"192.168.99.100:32401", "0.0.0.0:32401", "kafka-proxy-0:32401"},
-				{"192.168.99.100:32402", "0.0.0.0:32402", "kafka-proxy-0:32402"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32401",
+					ListenerAddress:   "0.0.0.0:32401",
+					AdvertisedAddress: "kafka-proxy-0:32401",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32402",
+					ListenerAddress:   "0.0.0.0:32402",
+					AdvertisedAddress: "kafka-proxy-0:32402",
+				},
 			},
 			[]config.ListenerConfig{
-				{"192.168.99.100:32403", "kafka-proxy-0:32403", "kafka-proxy-0:32403"},
-				{"192.168.99.100:32404", "kafka-proxy-0:32404", "kafka-proxy-0:32404"},
+				{
+					BrokerAddress:     "192.168.99.100:32403",
+					ListenerAddress:   "kafka-proxy-0:32403",
+					AdvertisedAddress: "kafka-proxy-0:32403"},
+				{
+					BrokerAddress:     "192.168.99.100:32404",
+					ListenerAddress:   "kafka-proxy-0:32404",
+					AdvertisedAddress: "kafka-proxy-0:32404"},
 			},
 			nil,
 			map[string]config.ListenerConfig{
@@ -136,10 +195,18 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "kafka-proxy-0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
 			},
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "kafka-proxy-0:32400", "kafka-proxy-0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "kafka-proxy-0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
 			},
 			nil,
 			map[string]config.ListenerConfig{
@@ -152,10 +219,18 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		},
 		{
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "0.0.0.0:32400", "kafka-proxy-0:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "0.0.0.0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
 			},
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "kafka-proxy-1:32400", "kafka-proxy-1:32400"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "kafka-proxy-1:32400",
+					AdvertisedAddress: "kafka-proxy-1:32400",
+				},
 			},
 			fmt.Errorf("bootstrap and external server mappings 192.168.99.100:32400 with different advertised addresses: kafka-proxy-1:32400 and kafka-proxy-0:32400"),
 			nil,
@@ -163,7 +238,11 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		{
 			[]config.ListenerConfig{},
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "kafka-proxy-0:32400", "kafka-proxy-0:32401"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "kafka-proxy-0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32401",
+				},
 			},
 			fmt.Errorf("external server mapping has different listener and advertised addresses {192.168.99.100:32400 kafka-proxy-0:32400 kafka-proxy-0:32401}"),
 			nil,
@@ -171,8 +250,16 @@ func TestGetBrokerToListenerConfig(t *testing.T) {
 		{
 			[]config.ListenerConfig{},
 			[]config.ListenerConfig{
-				{"192.168.99.100:32400", "kafka-proxy-0:32400", "kafka-proxy-0:32400"},
-				{"192.168.99.100:32400", "kafka-proxy-0:32401", "kafka-proxy-0:32401"},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "kafka-proxy-0:32400",
+					AdvertisedAddress: "kafka-proxy-0:32400",
+				},
+				{
+					BrokerAddress:     "192.168.99.100:32400",
+					ListenerAddress:   "kafka-proxy-0:32401",
+					AdvertisedAddress: "kafka-proxy-0:32401",
+				},
 			},
 			fmt.Errorf("external server mapping 192.168.99.100:32400 configured twice: kafka-proxy-0:32401 and {192.168.99.100:32400 kafka-proxy-0:32400 kafka-proxy-0:32400}"),
 			nil,


### PR DESCRIPTION
This is an enhancement to the dynamic listeners capability, which adds this functionality:

* Is enabled via the `--deterministic-listeners` flag
* When enabled (with dynamic listeners), use broker ID + minimum port to determine listening port (this means that if multiple instances are run in front of a Kafka cluster, all instances will use the same listening ports)
* Maintain a mapping of broker IDs to broker addresses (and `net.Listener` objects)
* If we see a broker with the same broker ID, but a different upstream listener, close the `net.Listener` and create a new one pointing at the new upstream listener

This is built to support clusters where broker hostnames and ports are not deterministic. Specifically, multiple Confluent Cloud cluster types re-use broker IDs with randomly generated hostnames; this PR enables the Kafka-Proxy to work with these Confluent Cloud clusters.

@everesio any thoughts on this? Would love your input here!