### PR TITLE
Support proprietary API Keys

### DIFF
--- a/proxy/processor.go
+++ b/proxy/processor.go
@@ -21,7 +21,7 @@ const (
 	apiKeyApiApiVersions = int16(18)
 
 	minRequestApiKey = int16(0)   // 0 - Produce
-	maxRequestApiKey = int16(120) // so far 67 is the last (reserve some for the feature)
+	maxRequestApiKey = int16(20000) // so far 67 is the last (reserve some for the feature)
 )
 
 var (


### PR DESCRIPTION
Certain Kafka providers (including Confluent) add custom APIs that use API key versions > 10000. Right now, Kafka Proxy drops these on the floor.

This change increases the max API key version supported by Kafka Proxy to 20000, so that these are transparently passed through (in both directions).