### PR TITLE
fix(Dockerfile): bump alpine version and set uid for 'kafka-proxy' …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.19 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.21 AS builder
 RUN apk add alpine-sdk ca-certificates
 
 ARG TARGETOS
@@ -21,7 +21,7 @@ RUN mkdir -p build && \
     go build -mod=vendor -o build/kafka-proxy \
     -ldflags "${LDFLAGS}" .
 
-FROM --platform=$BUILDPLATFORM alpine:3.19
+FROM --platform=$BUILDPLATFORM alpine:3.21
 RUN apk add --no-cache ca-certificates libcap
 RUN adduser \
         --disabled-password \

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.19 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine3.21 AS builder
 RUN apk add alpine-sdk ca-certificates
 
 ARG TARGETOS
@@ -27,7 +27,7 @@ RUN mkdir -p build && \
     go build -mod=vendor -o build/unsecured-jwt-provider -ldflags "${LDFLAGS}" cmd/plugin-unsecured-jwt-provider/main.go && \
     go build -mod=vendor -o build/oidc-provider -ldflags "${LDFLAGS}" cmd/plugin-oidc-provider/main.go
 
-FROM --platform=$BUILDPLATFORM alpine:3.19
+FROM --platform=$BUILDPLATFORM alpine:3.21
 RUN apk add --no-cache ca-certificates libcap
 RUN adduser \
         --disabled-password \
@@ -50,4 +50,3 @@ RUN setcap 'cap_net_bind_service=+ep' /opt/kafka-proxy/bin/kafka-proxy && \
 USER kafka-proxy
 ENTRYPOINT ["/opt/kafka-proxy/bin/kafka-proxy"]
 CMD ["--help"]
-

--- a/README.md
+++ b/README.md
@@ -496,6 +496,17 @@ spec:
           ports:
           - name: metrics
             containerPort: 9080
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            seccompProfile:
+              type: RuntimeDefault
           livenessProbe:
             httpGet:
               path: /health
@@ -591,6 +602,17 @@ spec:
             mountPath: "/var/run/secret/kafka-client-certificate"
           - name: "tls-client-key-file"
             mountPath: "/var/run/secret/kafka-client-key"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            seccompProfile:
+              type: RuntimeDefault
           ports:
           - name: metrics
             containerPort: 9080


### PR DESCRIPTION
…user

In order to implement https://kubernetes.io/docs/concepts/security/pod-security-standards/ for set to 'restricted', the container need to run as non-root.