### PR TITLE
Intercept and rewrite ApiVersionsResponse to prevent negotiation of API keys that kafka-proxy doesn't support

### DIFF
--- a/proxy/processor_default.go
+++ b/proxy/processor_default.go
@@ -158,7 +158,9 @@ func (handler *DefaultRequestHandler) mustReply(requestKeyVersion *protocol.Requ
 			if err != nil {
 				return false, nil, err
 			}
-
+		
+		// Reminder: When adding support for new versions of the produce request, also update proxy/protocol/responses.go
+		// Change 'apiKeyProduceMaxVersion' when adding new version support
 		case 3, 4, 5, 6, 7, 8, 9, 10, 11:
 			// CorrelationID + ClientID
 			if err = acksReader.ReadAndDiscardHeaderV1Part(reader); err != nil {

--- a/proxy/protocol/responses.go
+++ b/proxy/protocol/responses.go
@@ -244,7 +244,32 @@ func createMetadataResponseSchemaVersions() []Schema {
 		&SchemaTaggedFields{Name: "response_tagged_fields"},
 	)
 
-	return []Schema{metadataResponseV0, metadataResponseV1, metadataResponseV2, metadataResponseV3, metadataResponseV4, metadataResponseV5, metadataResponseV6, metadataResponseV7, metadataResponseV8, metadataResponseV9, metadataResponseV10, metadataResponseV11, metadataResponseV12}
+	metadataResponseV13 := NewSchema("metadata_response_v13",
+		&Mfield{Name: "throttle_time_ms", Ty: TypeInt32},
+		&CompactArray{Name: brokersKeyName, Ty: metadataBrokerSchema9},
+		&Mfield{Name: "cluster_id", Ty: TypeCompactNullableStr},
+		&Mfield{Name: "controller_id", Ty: TypeInt32},
+		&CompactArray{Name: "topic_metadata", Ty: topicMetadataSchema12},
+		&Mfield{Name: "error_code", Ty: TypeInt16},
+		&SchemaTaggedFields{Name: "response_tagged_fields"},
+	)
+
+	return []Schema{
+		metadataResponseV0,
+		metadataResponseV1,
+		metadataResponseV2,
+		metadataResponseV3,
+		metadataResponseV4,
+		metadataResponseV5,
+		metadataResponseV6,
+		metadataResponseV7,
+		metadataResponseV8,
+		metadataResponseV9,
+		metadataResponseV10,
+		metadataResponseV11,
+		metadataResponseV12,
+		metadataResponseV13,
+	}
 }
 
 func createFindCoordinatorResponseSchemaVersions() []Schema {


### PR DESCRIPTION
Split https://github.com/grepplabs/kafka-proxy/pull/184 into two separate PRs:

* Add support for metadata response v13 (added in AK 4.0 as part of KIP-1102)
* Add API key version limiting (separate PR) <- this PR


Example scenario:
* Client supports Metadata (3) Request/Response v14
* Server supports Metadata (3) Request/Response v14
* Kafka Proxy only knows how to parse and rewrite Metadata (3) Response v13

Prior to this change, this is the workflow (through KP)
* Client submits ApiVersions Request to Broker (passed through KP)
* Broker responds with ApiVersions Response to Client, including Metadata(3) v14 (passed through KP)
* Client sees that both client and server support Metadata(3) v14, and sends Metadata(3) Request v14 (passed through KP)
* Server responds with Metadata(3) Response v14 (intercepted by KP, and dropped on the floor because KP doesn't know how to parse it)

Post this change, this is the workflow (through KP):
* Client submits ApiVersions Request to Broker (passed through KP)
* Broker responds with ApiVersions Response to Client, including Metadata(3) v14
* KP intercepts ApiVersions Response, sees Metadata(3) v14 in the list of supported API Versions, and rewrites it to Metadata(3) v13 before sending it back to KP
* Client sees that broker 'only' supports Metadata(3) v13, and sends Metadata(3) Request v13 (passed through KP)
* Server responds with Metadata(3) Response v13 (which KP rewrites with new advertised listeners)