### PR TITLE
Allow constraining dynamic listener ports to a specific port interval (range)

### DIFF
--- a/cmd/kafka-proxy/server.go
+++ b/cmd/kafka-proxy/server.go
@@ -93,7 +93,8 @@ func initFlags() {
 	Server.Flags().StringArrayVar(&dialAddressMapping, "dial-address-mapping", []string{}, "Mapping of target broker address to new one (host:port,host:port). The mapping is performed during connection establishment")
 	Server.Flags().BoolVar(&c.Proxy.DeterministicListeners, "deterministic-listeners", false, "Enable deterministic listeners (listener port = min port + broker id).")
 	Server.Flags().BoolVar(&c.Proxy.DisableDynamicListeners, "dynamic-listeners-disable", false, "Disable dynamic listeners.")
-	Server.Flags().IntVar(&c.Proxy.DynamicSequentialMinPort, "dynamic-sequential-min-port", 0, "If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.")
+	Server.Flags().Uint16Var(&c.Proxy.DynamicSequentialMinPort, "dynamic-sequential-min-port", 0, "If set to non-zero, makes the dynamic listener use a sequential port starting with this value rather than a random port every time.")
+	Server.Flags().Uint16Var(&c.Proxy.DynamicSequentialMaxPorts, "dynamic-sequential-max-ports", 0, "If set to non-zero, ports are allocated sequentially from the half open interval [dynamic-sequential-min-port, dynamic-sequential-min-port + dynamic-sequential-max-ports)")
 
 	Server.Flags().IntVar(&c.Proxy.RequestBufferSize, "proxy-request-buffer-size", 4096, "Request buffer size pro tcp connection")
 	Server.Flags().IntVar(&c.Proxy.ResponseBufferSize, "proxy-response-buffer-size", 4096, "Response buffer size pro tcp connection")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -28,9 +28,11 @@ type Listeners struct {
 
 	listenFunc ListenFunc
 
-	deterministicListeners   bool
-	disableDynamicListeners  bool
-	dynamicSequentialMinPort int
+	deterministicListeners    bool
+	disableDynamicListeners   bool
+	dynamicSequentialMinPort  uint16
+	currentDynamicPortCounter uint64
+	dynamicSequentialMaxPorts uint16
 
 	brokerToListenerConfig map[string]*ListenerConfig
 	lock                   sync.RWMutex
@@ -74,6 +76,8 @@ func NewListeners(cfg *config.Config) (*Listeners, error) {
 		deterministicListeners:    cfg.Proxy.DeterministicListeners,
 		disableDynamicListeners:   cfg.Proxy.DisableDynamicListeners,
 		dynamicSequentialMinPort:  cfg.Proxy.DynamicSequentialMinPort,
+		currentDynamicPortCounter: 0,
+		dynamicSequentialMaxPorts: cfg.Proxy.DynamicSequentialMaxPorts,
 	}, nil
 }
 
@@ -149,6 +153,16 @@ func (p *Listeners) findListenerConfig(brokerId int32) *ListenerConfig {
 	return nil
 }
 
+// Make sure all dynamically allocated ports are within the half open interval
+// [dynamicSequentialMinPort, dynamicSequentialMinPort + dynamicSequentialMaxPorts).
+func (p *Listeners) nextDynamicPort(portOffset uint64, brokerAddress string, brokerId int32) (uint16, error) {
+	port := p.dynamicSequentialMinPort + uint16(portOffset%uint64(p.dynamicSequentialMaxPorts))
+	if port < p.dynamicSequentialMinPort {
+		return 0, fmt.Errorf("port assignment overflow %s %d: %d", brokerAddress, brokerId, port)
+	}
+	return port, nil
+}
+
 func (p *Listeners) ListenDynamicInstance(brokerAddress string, brokerId int32) (string, int32, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
@@ -162,11 +176,11 @@ func (p *Listeners) ListenDynamicInstance(brokerAddress string, brokerId int32) 
 		if brokerId < 0 {
 			return "", 0, fmt.Errorf("brokerId is negative %s %d", brokerAddress, brokerId)
 		}
-		deterministicPort := p.dynamicSequentialMinPort + int(brokerId)
-		if deterministicPort < p.dynamicSequentialMinPort {
-			return "", 0, fmt.Errorf("port assignment overflow %s %d: %d", brokerAddress, brokerId, deterministicPort)
+		deterministicPort, err := p.nextDynamicPort(uint64(brokerId), brokerAddress, brokerId)
+		if err != nil {
+			return "", 0, err
 		}
-		listenerAddress = net.JoinHostPort(p.defaultListenerIP, strconv.Itoa(deterministicPort))
+		listenerAddress = net.JoinHostPort(p.defaultListenerIP, strconv.Itoa(int(deterministicPort)))
 		cfg := p.findListenerConfig(brokerId)
 		if cfg != nil {
 			oldBrokerAddress := cfg.GetBrokerAddress()
@@ -179,9 +193,17 @@ func (p *Listeners) ListenDynamicInstance(brokerAddress string, brokerId int32) 
 			return util.SplitHostPort(cfg.AdvertisedAddress)
 		}
 	} else {
-		listenerAddress = net.JoinHostPort(p.defaultListenerIP, strconv.Itoa(p.dynamicSequentialMinPort))
-		if p.dynamicSequentialMinPort != 0 {
-			p.dynamicSequentialMinPort += 1
+		if p.dynamicSequentialMinPort == 0 {
+			// Use random (non sequential) ephemeral free port, allocated by OS.
+			listenerAddress = net.JoinHostPort(p.defaultListenerIP, strconv.Itoa(0))
+		} else {
+			// Use sequentially allocated port.
+			port, err := p.nextDynamicPort(uint64(p.currentDynamicPortCounter), brokerAddress, brokerId)
+			if err != nil {
+				return "", 0, err
+			}
+			listenerAddress = net.JoinHostPort(p.defaultListenerIP, strconv.Itoa(int(port)))
+			p.currentDynamicPortCounter += 1
 		}
 	}
 	cfg := NewListenerConfig(brokerAddress, listenerAddress, "", brokerId)


### PR DESCRIPTION
A common operating scheme for Kafka and Kafka-compatible systems like for example Redpanda, is to apply rolling upgrades with monotonically increasing broker IDs. In our specific use case, using Redpanda Cloud, it turned out that broker IDs are monotonically increasing with each version upgrade or replacement (e.g. if a broker is move to another machine). _Broker IDs_ are implemented as signed 32-bit integers, and by conventions only zero and positive integers are used. TCP ports are 16-bit unsigned integers and thus we cannot simply increase port numbers beyond what fits into a 16-bit unsigned integer and we can also not use _Broker IDs_ as port numbers (e.g. as is currently implemented for [deterministic listeners](https://github.com/grepplabs/kafka-proxy/pull/191)).

Therefore with this PR we introduce the following backward compatible changes:

- refactor port numbers to be of type `uint16` (instead of `int`).
- introduce a new configuration (and command line) parameter `dynamic-sequential-max-ports`, specifying the maximum number of ports that can be used for dynamic listeners. Effectively, in combination with `dynamic-sequential-min-port` allowing users to define a half open port interval `[dynamic-sequential-min-port, dynamic-sequential-min-port + dynamic-sequential-max-ports)`, which is used to allocated dynamic ports.
- adding configuration validation to ensure that:
  - if `deterministic-listeners` or `dynamic-sequential-max-ports` is set, `dynamic-sequential-min-port` must also be set to a positive (non-zero) value.
  - `dynamic-sequential-max-ports` defaults to `65536 - dynamic-sequential-min-port` if `dynamic-sequential-min-port`is set to a non-zero value.

With those changes in place, dynamic port allocation will now only allocate ports from the above mentioned half open interval and will automatically wrap-over (safely-overflow) to the start of the interval when it reaches the end of the interval. The only exception is if `dynamic-sequential-min-port` is not set respectively is set to `0`, in that case we still delegate allocation of (random) free ephemeral ports to the OS.

# Motivation for this PR

Why do we need this changes, which problems are we solving?

- Ensure _dynamic deterministic listeners_ work even if _Broker IDs_ are greater than 65335
- Ensure _dynamic sequential listeners_ work even if the number of allocated ports overflows 65535
- Enable SecOps to limit the port-interval they have to open in firewalls (e.g. [SecurityGroups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) or [NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/))
- Ease usage of `kafka-proxy` behind a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/), which needs explicit definition of all ports.

