### PR TITLE
upgrade Go version to 1.24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           check-latest: true
       - run: go version
       - name: Run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,9 +20,9 @@ jobs:
           describe=$(git describe --tags --always --dirty)
           echo "GIT_COMMIT_REF_NAME=$describe" >> $GITHUB_ENV
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version-file: go.mod
           check-latest: true
       - run: go version
       - name: Run build and test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 AS builder
 RUN apk add alpine-sdk ca-certificates
 
 ARG TARGETOS

--- a/Dockerfile.all
+++ b/Dockerfile.all
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 AS builder
 RUN apk add alpine-sdk ca-certificates
 
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grepplabs/kafka-proxy
 
-go 1.23
+go 1.24
 
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5


### PR DESCRIPTION
## WHAT

This PR upgrade Go version to 1.24.0 and changes version specification for `actions/setup-go` from `go-version` to `go-version-file`

Go version upgrade was made this way
```
go mod edit -go=1.24
go mod tidy
go mod vendor
```

## WHY

Go 1.24 was released